### PR TITLE
Added means to create a provider that uses GET methods for the authentication urls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 target
+.settings
+.project
+.classpath

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>oauth.signpost</groupId>
   <artifactId>oauth-signpost</artifactId>
   <packaging>pom</packaging>
-  <version>1.2.1.1</version>
+  <version>1.2.1.2-SNAPSHOT</version>
   <name>oauth-signpost</name>
   <description>
     A simple, light-weight, and modular OAuth client library for the
@@ -119,12 +119,6 @@
       <name>Signpost Snapshot Repository</name>
       <url>http://oss.sonatype.org/content/repositories/signpost-snapshots/</url>
     </snapshotRepository>
-    <!-- 
-    <site>
-      <id>site-staging</id>
-      <url>site-preview</url>
-    </site>
-     -->
   </distributionManagement>
 
   <reporting>

--- a/signpost-commonshttp4/.classpath
+++ b/signpost-commonshttp4/.classpath
@@ -2,7 +2,7 @@
 <classpath>
 	<classpathentry kind="src" output="target/classes" path="src/main/java"/>
 	<classpathentry kind="src" output="target/test-classes" path="src/test/java"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>
 	<classpathentry kind="con" path="org.maven.ide.eclipse.MAVEN2_CLASSPATH_CONTAINER"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/signpost-commonshttp4/pom.xml
+++ b/signpost-commonshttp4/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <artifactId>oauth-signpost</artifactId>
     <groupId>oauth.signpost</groupId>
-    <version>1.2.1.1</version>
+    <version>1.2.1.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>signpost-commonshttp4</artifactId>
@@ -12,7 +12,7 @@
     <dependency>
       <groupId>oauth.signpost</groupId>
       <artifactId>signpost-core</artifactId>
-      <version>1.2.1.1</version>
+      <version>${project.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -30,10 +30,9 @@
     <dependency>
       <groupId>oauth.signpost</groupId>
       <artifactId>signpost-core</artifactId>
-      <version>1.2.1.1</version>
+      <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>    
   </dependencies>
-
 </project>

--- a/signpost-commonshttp4/src/main/java/oauth/signpost/commonshttp/CommonsHttpOAuthProvider.java
+++ b/signpost-commonshttp4/src/main/java/oauth/signpost/commonshttp/CommonsHttpOAuthProvider.java
@@ -18,6 +18,7 @@ import oauth.signpost.http.HttpRequest;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.impl.client.DefaultHttpClient;
@@ -44,18 +45,30 @@ public class CommonsHttpOAuthProvider extends AbstractOAuthProvider {
     }
 
     public CommonsHttpOAuthProvider(String requestTokenEndpointUrl, String accessTokenEndpointUrl,
+    		String authorizationWebsiteUrl, final String httpMethod) {
+    	super(requestTokenEndpointUrl, accessTokenEndpointUrl, authorizationWebsiteUrl, httpMethod);
+    	this.httpClient = new DefaultHttpClient();
+    }
+
+    public CommonsHttpOAuthProvider(String requestTokenEndpointUrl, String accessTokenEndpointUrl,
             String authorizationWebsiteUrl, HttpClient httpClient) {
         super(requestTokenEndpointUrl, accessTokenEndpointUrl, authorizationWebsiteUrl);
         this.httpClient = httpClient;
     }
-
+    
+    public CommonsHttpOAuthProvider(String requestTokenEndpointUrl, String accessTokenEndpointUrl,
+    		String authorizationWebsiteUrl, HttpClient httpClient, String httpMethod) {
+    	super(requestTokenEndpointUrl, accessTokenEndpointUrl, authorizationWebsiteUrl, httpMethod);
+    	this.httpClient = httpClient;
+    }
+    
     public void setHttpClient(HttpClient httpClient) {
         this.httpClient = httpClient;
     }
 
     @Override
     protected HttpRequest createRequest(String endpointUrl) throws Exception {
-        HttpPost request = new HttpPost(endpointUrl);
+    	HttpUriRequest request = this.method.equals(HTTP_POST) ? new HttpPost(endpointUrl) : new HttpGet(endpointUrl);  
         return new HttpRequestAdapter(request);
     }
 

--- a/signpost-core/.classpath
+++ b/signpost-core/.classpath
@@ -2,7 +2,7 @@
 <classpath>
 	<classpathentry kind="src" output="target/classes" path="src/main/java"/>
 	<classpathentry kind="src" output="target/test-classes" path="src/test/java"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>
 	<classpathentry kind="con" path="org.maven.ide.eclipse.MAVEN2_CLASSPATH_CONTAINER"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/signpost-core/pom.xml
+++ b/signpost-core/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <artifactId>oauth-signpost</artifactId>
     <groupId>oauth.signpost</groupId>
-    <version>1.2.1.1</version>
+    <version>1.2.1.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>signpost-core</artifactId>

--- a/signpost-core/src/main/java/oauth/signpost/AbstractOAuthProvider.java
+++ b/signpost-core/src/main/java/oauth/signpost/AbstractOAuthProvider.java
@@ -31,7 +31,6 @@ import oauth.signpost.http.HttpResponse;
  * @author Matthias Kaeppler
  */
 public abstract class AbstractOAuthProvider implements OAuthProvider {
-
     private static final long serialVersionUID = 1L;
 
     private String requestTokenEndpointUrl;
@@ -47,14 +46,25 @@ public abstract class AbstractOAuthProvider implements OAuthProvider {
     private boolean isOAuth10a;
 
     private transient OAuthProviderListener listener;
-
+    
+    protected final String method;
+    
     public AbstractOAuthProvider(String requestTokenEndpointUrl, String accessTokenEndpointUrl,
-            String authorizationWebsiteUrl) {
+            String authorizationWebsiteUrl, final String httpMethod) {
         this.requestTokenEndpointUrl = requestTokenEndpointUrl;
         this.accessTokenEndpointUrl = accessTokenEndpointUrl;
         this.authorizationWebsiteUrl = authorizationWebsiteUrl;
         this.responseParameters = new HttpParameters();
         this.defaultHeaders = new HashMap<String, String>();
+        if (null == httpMethod || !(httpMethod.toUpperCase().equals("GET") || httpMethod.toUpperCase().equals("POST"))) {
+        	throw new IllegalArgumentException("You must specify a valid httpMethod (GET or POST)");
+        } 
+    	this.method = httpMethod;
+    }
+
+    public AbstractOAuthProvider(String requestTokenEndpointUrl, String accessTokenEndpointUrl,
+            String authorizationWebsiteUrl) {
+    	this(requestTokenEndpointUrl, accessTokenEndpointUrl, authorizationWebsiteUrl, OAuthProvider.HTTP_POST);
     }
 
     public String retrieveRequestToken(OAuthConsumer consumer, String callbackUrl)

--- a/signpost-core/src/main/java/oauth/signpost/OAuthProvider.java
+++ b/signpost-core/src/main/java/oauth/signpost/OAuthProvider.java
@@ -83,6 +83,8 @@ import oauth.signpost.http.HttpParameters;
  * @see OAuthProviderListener
  */
 public interface OAuthProvider extends Serializable {
+	public static final String HTTP_GET = "GET";
+	public static final String HTTP_POST = "POST";
 
     /**
      * Queries the service provider for a request token.

--- a/signpost-core/src/main/java/oauth/signpost/basic/DefaultOAuthProvider.java
+++ b/signpost-core/src/main/java/oauth/signpost/basic/DefaultOAuthProvider.java
@@ -33,11 +33,16 @@ public class DefaultOAuthProvider extends AbstractOAuthProvider {
             String authorizationWebsiteUrl) {
         super(requestTokenEndpointUrl, accessTokenEndpointUrl, authorizationWebsiteUrl);
     }
+    
+    public DefaultOAuthProvider(String requestTokenEndpointUrl, String accessTokenEndpointUrl,
+            String authorizationWebsiteUrl, final String httpMethod) {
+        super(requestTokenEndpointUrl, accessTokenEndpointUrl, authorizationWebsiteUrl, httpMethod);
+    }
 
     protected HttpRequest createRequest(String endpointUrl) throws MalformedURLException,
             IOException {
         HttpURLConnection connection = (HttpURLConnection) new URL(endpointUrl).openConnection();
-        connection.setRequestMethod("POST");
+        connection.setRequestMethod(this.method);
         connection.setAllowUserInteraction(false);
         connection.setRequestProperty("Content-Length", "0");
         return new HttpURLConnectionRequestAdapter(connection);

--- a/signpost-jetty6/.classpath
+++ b/signpost-jetty6/.classpath
@@ -2,7 +2,7 @@
 <classpath>
 	<classpathentry kind="src" output="target/classes" path="src/main/java"/>
 	<classpathentry kind="src" output="target/test-classes" path="src/test/java"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>
 	<classpathentry kind="con" path="org.maven.ide.eclipse.MAVEN2_CLASSPATH_CONTAINER"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/signpost-jetty6/pom.xml
+++ b/signpost-jetty6/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <artifactId>oauth-signpost</artifactId>
     <groupId>oauth.signpost</groupId>
-    <version>1.2.1.1</version>
+    <version>1.2.1.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>signpost-jetty6</artifactId>
@@ -12,7 +12,7 @@
     <dependency>
       <groupId>oauth.signpost</groupId>
       <artifactId>signpost-core</artifactId>
-      <version>1.2.1.1</version>
+      <version>${project.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>oauth.signpost</groupId>
       <artifactId>signpost-core</artifactId>
-      <version>1.2.1.1</version>
+      <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>        


### PR DESCRIPTION
Providers can make the requests using GET or POST (some oauth providers, like MySpace, only offer the request_token, authorize_token, access_token urls over GET). Added new set of constructors to every OAuthProvider, these constructors require the http method (either GET or POST). Default method is POST.
