### PR TITLE
Fix for nested parameters causing invalid signatures

### DIFF
--- a/signpost-core/src/main/java/oauth/signpost/signature/SignatureBaseString.java
+++ b/signpost-core/src/main/java/oauth/signpost/signature/SignatureBaseString.java
@@ -110,6 +110,9 @@ public class SignatureBaseString {
                 sb.append("&");
             }
 
+			// Decode our parameters
+			param = OAuth.percentDecode(param);
+
             sb.append(requestParameters.getAsQueryString(param));
         }
         return sb.toString();


### PR DESCRIPTION
I was trying to submit nested parameters (i.e. object[attribute]=value ) and was getting invalid signatures from our OAuth provider.  

After tracing through the code,  I saw that already encoded parameters were getting double encoded when submitted to HTTPParameter's getAsQueryString.  In my branch, I modified SignatureBaseString's normalizeRequestParameters method to pass in decoded parameters to that method.  

This resolved the problem for me.  Thought I should pass this information back in case its of any use to you guys.
