### PR TITLE
Drop dependency on Apache Commons Codec

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,8 +77,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.3.2</version>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.6</source>
+          <target>1.6</target>
         </configuration>
       </plugin>
       <plugin>
@@ -121,7 +121,7 @@
       <name>Signpost Snapshot Repository</name>
       <url>http://oss.sonatype.org/content/repositories/signpost-snapshots/</url>
     </snapshotRepository>
-    <!-- 
+    <!--
     <site>
       <id>site-staging</id>
       <url>site-preview</url>
@@ -135,7 +135,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>2.8</version>
       </plugin>
-      <!-- 
+      <!--
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>jxr-maven-plugin</artifactId>
@@ -170,12 +170,12 @@
                   </configuration>
                 </execution>
               </executions>
-            </plugin>        
+            </plugin>
           </plugins>
         </pluginManagement>
       </build>
     </profile>
-  
+
     <profile>
       <id>release-sign-artifacts</id>
       <activation>

--- a/signpost-core/pom.xml
+++ b/signpost-core/pom.xml
@@ -7,22 +7,14 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>signpost-core</artifactId>
   <name>signpost-core</name>
-   
+
   <!-- dependencies -->
-  <dependencies>
-    <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
-      <version>1.3</version>
-      <scope>compile</scope>
-    </dependency>
-  </dependencies>
 
   <build>
     <plugins>
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
-      </plugin>    
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/signpost-core/src/main/java/oauth/signpost/signature/OAuthMessageSigner.java
+++ b/signpost-core/src/main/java/oauth/signpost/signature/OAuthMessageSigner.java
@@ -16,26 +16,19 @@ package oauth.signpost.signature;
 
 import java.io.IOException;
 import java.io.Serializable;
+import javax.xml.bind.DatatypeConverter;
 
 import oauth.signpost.exception.OAuthMessageSignerException;
-import oauth.signpost.http.HttpRequest;
 import oauth.signpost.http.HttpParameters;
-
-import org.apache.commons.codec.binary.Base64;
+import oauth.signpost.http.HttpRequest;
 
 public abstract class OAuthMessageSigner implements Serializable {
 
     private static final long serialVersionUID = 4445779788786131202L;
 
-    private transient Base64 base64;
-
     private String consumerSecret;
 
     private String tokenSecret;
-
-    public OAuthMessageSigner() {
-        this.base64 = new Base64();
-    }
 
     public abstract String sign(HttpRequest request, HttpParameters requestParameters)
             throws OAuthMessageSignerException;
@@ -59,16 +52,15 @@ public abstract class OAuthMessageSigner implements Serializable {
     }
 
     protected byte[] decodeBase64(String s) {
-        return base64.decode(s.getBytes());
+        return DatatypeConverter.parseBase64Binary(s);
     }
 
     protected String base64Encode(byte[] b) {
-        return new String(base64.encode(b));
+        return DatatypeConverter.printBase64Binary(b);
     }
 
     private void readObject(java.io.ObjectInputStream stream)
             throws IOException, ClassNotFoundException {
         stream.defaultReadObject();
-        this.base64 = new Base64();
     }
 }


### PR DESCRIPTION
This is effectively the same as #13, but only requires Java 1.6.

The dependency was only needed for Base64 conversion, which is now done by javax.xml.bind.DatatypeConverter which is part of JAXB 1.0+. As JAXB 2.0+ is part of the Java platform since Java 1.6, a minimum Java version of 1.6 is required.
