### PR TITLE
Support for HmacSHA256.

### DIFF
--- a/signpost-core/src/main/java/oauth/signpost/OAuthConsumer.java
+++ b/signpost-core/src/main/java/oauth/signpost/OAuthConsumer.java
@@ -64,6 +64,7 @@ public interface OAuthConsumer extends Serializable {
      * @param messageSigner
      *        the signer
      * @see HmacSha1MessageSigner
+     * @see HmacSha256MessageSigner
      * @see PlainTextMessageSigner
      */
     public void setMessageSigner(OAuthMessageSigner messageSigner);

--- a/signpost-core/src/main/java/oauth/signpost/signature/HmacSha256MessageSigner.java
+++ b/signpost-core/src/main/java/oauth/signpost/signature/HmacSha256MessageSigner.java
@@ -1,0 +1,61 @@
+/* Copyright (c) 2009 Matthias Kaeppler
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package oauth.signpost.signature;
+
+import java.io.UnsupportedEncodingException;
+import java.security.GeneralSecurityException;
+
+import javax.crypto.Mac;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+import oauth.signpost.OAuth;
+import oauth.signpost.exception.OAuthMessageSignerException;
+import oauth.signpost.http.HttpRequest;
+import oauth.signpost.http.HttpParameters;
+
+@SuppressWarnings("serial")
+public class HmacSha256MessageSigner extends OAuthMessageSigner {
+    private static final String MAC_NAME = "HmacSHA256";
+
+    @Override
+    public String getSignatureMethod() {
+        return "HMAC-SHA256";
+    }
+
+    @Override
+    public String sign(HttpRequest request, HttpParameters requestParams)
+            throws OAuthMessageSignerException {
+        try {
+            String keyString = OAuth.percentEncode(getConsumerSecret()) + '&'
+                    + OAuth.percentEncode(getTokenSecret());
+            byte[] keyBytes = keyString.getBytes(OAuth.ENCODING);
+
+            SecretKey key = new SecretKeySpec(keyBytes, MAC_NAME);
+            Mac mac = Mac.getInstance(MAC_NAME);
+            mac.init(key);
+
+            String sbs = new SignatureBaseString(request, requestParams).generate();
+            OAuth.debugOut("SBS", sbs);
+            byte[] text = sbs.getBytes(OAuth.ENCODING);
+
+            return base64Encode(mac.doFinal(text)).trim();
+        } catch (GeneralSecurityException e) {
+            throw new OAuthMessageSignerException(e);
+        } catch (UnsupportedEncodingException e) {
+            throw new OAuthMessageSignerException(e);
+        }
+    }
+}

--- a/signpost-core/src/test/java/oauth/signpost/signature/OAuthMessageSignerTest.java
+++ b/signpost-core/src/test/java/oauth/signpost/signature/OAuthMessageSignerTest.java
@@ -43,4 +43,24 @@ public class OAuthMessageSignerTest extends SignpostTestBase {
 
         assertEquals("tR3+Ty81lMeYAr/Fid0kMTYa/WM=", signer.sign(request, params));
     }
+
+    @Test
+    public void shouldComputeCorrectHmacSha256Signature() throws Exception {
+        // based on the reference test case from
+        // http://oauth.pbwiki.com/TestCases
+        OAuthMessageSigner signer = new HmacSha256MessageSigner();
+        signer.setConsumerSecret(CONSUMER_SECRET);
+        signer.setTokenSecret(TOKEN_SECRET);
+
+        HttpRequest request = mock(HttpRequest.class);
+        when(request.getRequestUrl()).thenReturn("http://photos.example.net/photos");
+        when(request.getMethod()).thenReturn("GET");
+
+        HttpParameters params = new HttpParameters();
+        params.putAll(OAUTH_PARAMS);
+        params.put("file", "vacation.jpg");
+        params.put("size", "original");
+
+        assertEquals("0gCtTYQAxqCKhIE0sltgx7UgHkAs10vrpuYE7xpRBnE=", signer.sign(request, params));
+    }
 }


### PR DESCRIPTION
Some services now require HmacSHA256 such as VitaDock's API.  This change is based on the HmacSHA1 implementation, but simply uses a different encryption algorithm.  Please let me know if more is required.  Thanks.