### PR TITLE
Replace deprecated expression in main pom file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
                   </goals>
                   <configuration>
                     <tasks>
-                      <copy file="${build.directory}/${build.finalName}.${project.packaging}" todir="${copyTo}" />
+                      <copy file="${project.build.directory}/${project.build.finalName}.${project.packaging}" todir="${copyTo}" />
                     </tasks>
                   </configuration>
                 </execution>


### PR DESCRIPTION
Avoid to see the following warnings running Maven 3:

```
[WARNING] Some problems were encountered while building the effective model for oauth.signpost:oauth-signpost:pom:1.2.1.2
[WARNING] The expression ${build.directory} is deprecated. Please use ${project.build.directory} instead.
[WARNING] The expression ${build.finalName} is deprecated. Please use ${project.build.finalName} instead.
```

Tested with Maven `3.3.9` and Java `1.7.0_101`.
