### PR TITLE
validatingConsumer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,19 @@ target
 /signpost-commonshttp4/.settings/
 /signpost-core/.settings/
 .DS_Store
+
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+*.iml
+# User-specific stuff:
+.idea/
+
+## File-based project format:
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/

--- a/signpost-commonshttp4/src/main/java/oauth/signpost/commonshttp/ValidatingCommonsOAuthConsumer.java
+++ b/signpost-commonshttp4/src/main/java/oauth/signpost/commonshttp/ValidatingCommonsOAuthConsumer.java
@@ -1,0 +1,30 @@
+package oauth.signpost.commonshttp;
+
+/**
+ * An extension of the {@link CommonsHttpOAuthConsumer} that allows timestamp and nonce to be specified.
+ * Useful for validating the signature of incoming requests. In order to perform the validation, 
+ * just generate a signature for the same method, URL, consumer key, timestamp and nonce as the incoming request, and
+ * use the shared secret that you know. If the generated signature matches the one of the incoming request, then
+ * it is valid.
+ */
+public class ValidatingCommonsOAuthConsumer extends CommonsHttpOAuthConsumer {
+
+	private final String timestamp;
+	private final String nonce;
+
+	public ValidatingCommonsOAuthConsumer(String consumerKey, String consumerSecret, String timestamp, String nonce) {
+		super(consumerKey, consumerSecret);
+		this.timestamp = timestamp;
+		this.nonce = nonce;
+	}
+
+	@Override
+	protected String generateTimestamp() {
+		return timestamp;
+	}
+
+	@Override
+	protected String generateNonce() {
+		return nonce;
+	}
+}


### PR DESCRIPTION
Adding a consumer that allows timestamp and nonce to be overriden with provided values.
Useful for server-side validation of Oauth signed requests.