### PR TITLE
Patch signpost-jetty6 against CVE-2009-4611

### DIFF
--- a/signpost-jetty6/pom.xml
+++ b/signpost-jetty6/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>org.mortbay.jetty</groupId>
       <artifactId>jetty-client</artifactId>
-      <version>6.1.18</version>
+      <version>6.1.26</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This would still let the package vulnerable to CVE-2011-4461 but solving
this one would require to move to `org.eclipse.jetty:jetty-server`,
which does not maintain a 6.x branch.