### PR TITLE
Patch commonshttp4 against CWE-23 directory traversal attack

### DIFF
--- a/signpost-commonshttp4/pom.xml
+++ b/signpost-commonshttp4/pom.xml
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.3.6</version>
+      <version>4.5.12</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Upgrading to 4.5.3 would be sufficient to patch this, but it is possible
to bump the latest available version while we're at it.